### PR TITLE
use application name instead of username in pghero connection stats

### DIFF
--- a/lib/pghero/methods/connections.rb
+++ b/lib/pghero/methods/connections.rb
@@ -42,7 +42,7 @@ module PgHero
         select_all <<-SQL
           SELECT
             datname AS database,
-            usename AS user,
+            application_name AS user,
             COUNT(*) AS total_connections
           FROM
             pg_stat_activity

--- a/lib/pghero/version.rb
+++ b/lib/pghero/version.rb
@@ -1,3 +1,3 @@
 module PgHero
-  VERSION = "2.2.9"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
Pulling Christos's changes into Instacart pghero repo. Blazer Gemfile currently refers to Christo's copy:

gem 'pghero', '>= 2.3.0', github: 'christoudias/pghero', require: 'pghero'

I will update that in a separate PR.