### PR TITLE
New tables for query blocker tracking

### DIFF
--- a/lib/generators/pghero/blocker_sample_sessions_generator.rb
+++ b/lib/generators/pghero/blocker_sample_sessions_generator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# taken from https://github.com/collectiveidea/audited/blob/master/lib/generators/audited/install_generator.rb
+require 'rails/generators'
+require 'rails/generators/migration'
+require 'active_record'
+require 'rails/generators/active_record'
+
+module Pghero
+  module Generators
+    class BlockerSampleSessionsGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+
+      source_root File.expand_path('../templates', __FILE__)
+
+      # Implement the required interface for Rails::Generators::Migration.
+      def self.next_migration_number(dirname) #:nodoc:
+        next_migration_number = current_migration_number(dirname) + 1
+        if ::ActiveRecord::Base.timestamped_migrations
+          [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % next_migration_number].max
+        else
+          '%.3d' % next_migration_number
+        end
+      end
+
+      def copy_migration
+        migration_template 'blocker_sample_sessions.rb',
+                           'db/migrate/create_pghero_blocker_sample_sessions.rb',
+                           migration_version: migration_version
+      end
+
+      def migration_version
+        return unless ActiveRecord::VERSION::MAJOR >= 5
+
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+      end
+    end
+  end
+end

--- a/lib/generators/pghero/blocker_samples_generator.rb
+++ b/lib/generators/pghero/blocker_samples_generator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# taken from https://github.com/collectiveidea/audited/blob/master/lib/generators/audited/install_generator.rb
+require 'rails/generators'
+require 'rails/generators/migration'
+require 'active_record'
+require 'rails/generators/active_record'
+
+module Pghero
+  module Generators
+    class BlockerSamplesGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+
+      source_root File.expand_path('../templates', __FILE__)
+
+      # Implement the required interface for Rails::Generators::Migration.
+      def self.next_migration_number(dirname) #:nodoc:
+        next_migration_number = current_migration_number(dirname) + 1
+        if ::ActiveRecord::Base.timestamped_migrations
+          [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % next_migration_number].max
+        else
+          '%.3d' % next_migration_number
+        end
+      end
+
+      def copy_migration
+        migration_template 'blocker_samples.rb',
+                           'db/migrate/create_pghero_blocker_samples.rb',
+                           migration_version: migration_version
+      end
+
+      def migration_version
+        return unless ActiveRecord::VERSION::MAJOR >= 5
+
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+      end
+    end
+  end
+end

--- a/lib/generators/pghero/templates/blocker_sample_sessions.rb.tt
+++ b/lib/generators/pghero/templates/blocker_sample_sessions.rb.tt
@@ -1,0 +1,31 @@
+class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pghero_blocker_sample_sessions do |t|
+      t.integer :blocker_sample_id, limit: 8
+      t.integer :pid
+      t.text :user
+      t.text :source
+      t.inet :client_addr
+      t.text :client_hostname
+      t.integer :client_port
+      t.timestamp :backend_start
+      t.timestamp :xact_start
+      t.timestamp :query_start
+      t.timestamp :state_change
+      t.text :wait_event_type
+      t.text :wait_event
+      t.text :state
+      t.integer :backend_xid, limit: 8
+      t.integer :backend_xmin, limit: 8
+      t.text :query
+      t.integer :query_hash, limit: 8
+      t.text :backend_type
+      t.integer :blocked_by, array: true
+      t.integer :blocking, array: true
+    end
+
+    add_foreign_key :pghero_blocker_sample_sessions, :pghero_blocker_samples, column: :blocker_sample_id
+
+    add_index :pghero_blocker_sample_sessions, :blocker_sample_id
+  end
+end

--- a/lib/generators/pghero/templates/blocker_samples.rb.tt
+++ b/lib/generators/pghero/templates/blocker_samples.rb.tt
@@ -1,0 +1,13 @@
+class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :pghero_blocker_samples do |t|
+      t.text :database
+      t.timestamp :captured_at
+      t.integer :txid_xmin, limit: 8
+      t.integer :txid_xmax, limit: 8
+      t.integer :txid_xip, limit: 8, array: true
+    end
+
+    add_index :pghero_blocker_samples, [:database, :captured_at]
+  end
+end


### PR DESCRIPTION
Schema only so the migration can be tested and performed before the dependent code changes are pushed.