### PR TITLE
Add query blocker tracking based on pg_blocking_pids()

### DIFF
--- a/guides/Linux.md
+++ b/guides/Linux.md
@@ -225,7 +225,7 @@ CREATE TABLE "pghero_connection_stats" (
   "username" text, 
   "captured_at" timestamp
 );
-CREATE  INDEX  "pghero_connection_stats" ("database", "captured_at");
+CREATE INDEX ON "pghero_connection_stats" ("database", "captured_at");
 ```
 
 Schedule the task below to run once a day.
@@ -234,6 +234,14 @@ Schedule the task below to run once a day.
 sudo pghero run rake pghero:capture_connection_stats
 ```
 
+## Historical Query Blockers
+
+To track query blockers over time, create a table to store them.
+
+TODO 
+```sql
+CREATE TABLE ...
+```
 
 ## System Stats
 

--- a/guides/Rails.md
+++ b/guides/Rails.md
@@ -303,6 +303,12 @@ PgHero.drop_user("ganondorf")
 
 ## Upgrading
 
+### 2.x.y
+
+New features
+
+Sample blocker queries - TODO
+
 ### 2.0.0
 
 New features

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -142,9 +142,15 @@ module PgHero
       end
     end
 
-    def capture_query_blockers(verbose: false)
+    def capture_query_blockers(verbose: false, filters: nil)
       each_database do |database|
-        next unless database.capture_query_blockers?
+        if filters && filters.none? { |f| f =~ database.id }
+          puts "Database #{database.id} did not match any filter; skipping." if verbose
+          next
+        elsif !database.capture_query_blockers?
+          puts "Database #{database.id} capture_query_blockers is disabled via configuration; skipping." if verbose
+          next
+        end
 
         puts "Capturing query blockers for #{database.id}..." if verbose
         database.capture_query_blockers

--- a/lib/pghero.rb
+++ b/lib/pghero.rb
@@ -148,12 +148,27 @@ module PgHero
           puts "Database #{database.id} did not match any filter; skipping." if verbose
           next
         elsif !database.capture_query_blockers?
-          puts "Database #{database.id} capture_query_blockers is disabled via configuration; skipping." if verbose
+          if verbose
+            puts "Database #{database.id} capture_query_blockers "\
+               "is disabled via configuration; skipping."
+          end
           next
         end
 
         puts "Capturing query blockers for #{database.id}..." if verbose
-        database.capture_query_blockers
+        begin
+          blocker_sample = database.capture_query_blockers
+          if verbose
+            if blocker_sample
+              puts "Captured blocker sample #{blocker_sample.id} "\
+                   "for #{database.id} with #{blocker_sample.sessions.size} sessions."
+            else
+              puts "No blocker sample returned for #{database.id}."
+            end
+          end
+        rescue NotEnabled => e
+          puts "Query blockers not enabled for #{database.id}: #{e.message}"
+        end
       end
     end
 

--- a/lib/pghero/base_database.rb
+++ b/lib/pghero/base_database.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PgHero
+  class BaseDatabase
+
+    include Methods::Basic
+
+    # Subclasses must define connection_model returning and ActiveRecord model
+    # for connection management
+
+    def connection
+      connection_model.connection
+    end
+  end
+end

--- a/lib/pghero/connection.rb
+++ b/lib/pghero/connection.rb
@@ -1,5 +1,0 @@
-module PgHero
-  class Connection < ActiveRecord::Base
-    self.abstract_class = true
-  end
-end

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -42,10 +42,6 @@ module PgHero
       config["capture_query_stats"] != false
     end
 
-    def capture_query_blockers?
-      config["capture_query_blockers"] != false
-    end
-
     def cache_hit_rate_threshold
       (config["cache_hit_rate_threshold"] || PgHero.config["cache_hit_rate_threshold"] || PgHero.cache_hit_rate_threshold).to_i
     end

--- a/lib/pghero/database.rb
+++ b/lib/pghero/database.rb
@@ -1,12 +1,17 @@
+# frozen_string_literal: true
+
+require "active_record"
+
 module PgHero
-  class Database
-    include Methods::Basic
+  class Database < BaseDatabase
+
     include Methods::Connections
     include Methods::Explain
     include Methods::Indexes
     include Methods::Kill
     include Methods::Maintenance
     include Methods::Queries
+    include Methods::QueryBlockers
     include Methods::QueryStats
     include Methods::Replication
     include Methods::Sequences
@@ -19,17 +24,18 @@ module PgHero
 
     attr_reader :id, :config
 
-    def initialize(id, config)
+    def initialize(id, config, repository)
       @id = id
       @config = config || {}
+      @repository = repository
     end
 
     def name
-      @name ||= @config["name"] || id.titleize
+      @name ||= config["name"] || id.titleize
     end
 
     def db_instance_identifier
-      @db_instance_identifier ||= @config["db_instance_identifier"]
+      @db_instance_identifier ||= config["db_instance_identifier"]
     end
 
     def capture_query_stats?
@@ -70,10 +76,12 @@ module PgHero
 
     private
 
+    attr_reader :repository
+
     def connection_model
       @connection_model ||= begin
         url = config["url"]
-        Class.new(PgHero::Connection) do
+        Class.new(Connection) do
           def self.name
             "PgHero::Connection::Database#{object_id}"
           end
@@ -86,6 +94,10 @@ module PgHero
           establish_connection url if url
         end
       end
+    end
+
+    class Connection < ActiveRecord::Base
+      self.abstract_class = true
     end
   end
 end

--- a/lib/pghero/methods/maintenance.rb
+++ b/lib/pghero/methods/maintenance.rb
@@ -34,7 +34,7 @@ module PgHero
       end
 
       def vacuum_progress
-        if server_version_num >= 90600
+        if server_version_num >= PgConst::VERSION_9_6
           select_all <<-SQL
             SELECT
               pid,

--- a/lib/pghero/methods/queries.rb
+++ b/lib/pghero/methods/queries.rb
@@ -8,7 +8,7 @@ module PgHero
             state,
             application_name AS source,
             age(NOW(), COALESCE(query_start, xact_start)) AS duration,
-            #{server_version_num >= 90600 ? "(wait_event IS NOT NULL) AS waiting" : "waiting"},
+            #{server_version_num >= PgConst::VERSION_9_6 ? "(wait_event IS NOT NULL) AS waiting" : "waiting"},
             query,
             COALESCE(query_start, xact_start) AS started_at,
             EXTRACT(EPOCH FROM NOW() - COALESCE(query_start, xact_start)) * 1000.0 AS duration_ms,

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require_relative 'type_const'
+
+module PgHero
+  module Methods
+    module QueryBlockers
+
+      def supports_query_blocker_monitoring?
+        supports_pg_blocking_pids?
+      end
+
+      def capture_query_blockers?
+        config['capture_query_blockers'] != false
+      end
+
+      def capture_query_blockers(raise_errors: false, save_empty_samples: true)
+        return unless capture_query_blockers?
+
+        sample_set = sample_query_blockers
+        if !sample_set.sessions.empty? || save_empty_samples
+          repository.insert_query_blockers(sample_set, raise_errors: raise_errors)
+        end
+        sample_set
+      end
+
+      def sample_query_blockers
+        raise NotEnabled, 'Query blockers requires Postgres 9.6+ support for pg_blocking_pids' unless supports_pg_blocking_pids?
+
+        SampleSet.new(self)
+      end
+
+      class SampleSet
+        # Do transforms (both normalization and de-normalization)
+        # to make the data easier for later analysis here rather
+        # than in SQL to minimize the cost on the monitored DB
+        # and the complexity of the (already complicated) query
+        # used for atomic data collection
+
+        BLOCKER_QUERY_COLUMNS =
+          TypeConst.const_column_list(
+            pid:                TypeConst::INTEGER,
+            user:               TypeConst::TEXT,
+            source:             TypeConst::TEXT,
+            client_addr:        TypeConst::INET,
+            client_hostname:    TypeConst::TEXT,
+            client_port:        TypeConst::INTEGER,
+            backend_start:      TypeConst::DATETIME,
+            xact_start:         TypeConst::DATETIME,
+            query_start:        TypeConst::DATETIME,
+            state_change:       TypeConst::TEXT,
+            wait_event_type:    TypeConst::TEXT,
+            wait_event:         TypeConst::TEXT,
+            state:              TypeConst::TEXT,
+            backend_xid:        TypeConst::XID,
+            backend_xmin:       TypeConst::XID,
+            query:              TypeConst::TEXT,
+            backend_type:       TypeConst::TEXT,
+            blocked_by:         TypeConst::INTEGER_ARRAY
+          )
+
+        BLOCKER_QUERY_COLUMN_NAMES =
+          BLOCKER_QUERY_COLUMNS.map(&:name).freeze
+
+        private_constant :BLOCKER_QUERY_COLUMNS, :BLOCKER_QUERY_COLUMN_NAMES
+
+        BLOCKER_ATTRIBUTE_COLUMNS =
+            (BLOCKER_QUERY_COLUMNS + TypeConst.const_column_list(blocking: TypeConst::INTEGER_ARRAY)).freeze
+
+
+        attr_reader :captured_at, :database, :txid_xmin, :txid_xmax, :txid_xip, :sessions
+        attr_accessor :id
+
+        def initialize(database)
+          records = database.select_all BLOCKER_SAMPLE_SET_SQL
+          first_record = records.first # Encodes whether the set has any real blockers
+
+          @captured_at = first_record[:sample_captured_at]
+          @database = first_record[:sample_database]
+          @txid_xmin = first_record[:sample_txid_xmin]
+          @txid_xmax = first_record[:sample_txid_xmax]
+          @txid_xip = first_record[:sample_txid_xip]
+
+          @sessions = first_record[:pid] ? rows_to_sessions(records) : {}
+        end
+
+        private
+
+        def rows_to_sessions(result)
+          session_cache = {}
+
+          result.map do |row|
+            current_pid = row[:pid]
+            session = row.slice(*BLOCKER_QUERY_COLUMN_NAMES)
+
+            # Might have already encountered earlier blockees
+            session[:blocking] = session_cache[current_pid]&.[](:blocking)
+            session_cache[current_pid] = session
+
+            session[:blocked_by]&.each do |blocker_pid|
+              add_blockee(current_pid, blocker_pid, session_cache)
+            end
+            session
+          end
+        end
+
+        def add_blockee(blockee_pid, blocker_pid, session_cache)
+          blocker_session = (session_cache[blocker_pid] ||= {})
+          (blocker_session[:blocking] ||= []).push(blockee_pid)
+        end
+
+        # Include inline SQL comments to document nuances of the query
+        # here (they execute fine); but they break internal quoting logic
+        # (that removes newlines) so strip them out for runtime use
+        BLOCKER_SAMPLE_SET_SQL = Basic.sql_const(<<-SQL)
+          WITH blocked_pids AS (
+            -- Pids of all sessions with blockers
+            SELECT
+              pid blocked_pid,
+              pg_blocking_pids(pid) AS blocked_by
+            FROM
+              pg_stat_activity
+            WHERE
+              CARDINALITY(pg_blocking_pids(pid)) > 0),
+
+          blockers_and_blockees as (
+            -- Details of all blockers and blockees; grab almost
+            -- everything since catching blockers via sampling
+            -- is hit and miss so forensic details are valuable
+            SELECT
+              psa.pid pid,
+              usename,
+              application_name,
+              client_addr,
+              client_hostname,
+              client_port,
+              backend_start,
+              xact_start,
+              query_start,
+              state_change,
+              wait_event_type,
+              wait_event,
+              state,
+              backend_xid,
+              backend_xmin,
+              query,
+              backend_type,
+              bp.blocked_by
+            FROM
+              pg_stat_activity psa
+            LEFT OUTER JOIN -- allows matching blockers as well as blockees
+              blocked_pids bp
+            ON
+              psa.pid = bp.blocked_pid -- normal join matches blockees
+            WHERE
+              datname = current_database()
+              AND (
+                bp.blocked_pid IS NOT NULL -- blockees that already matched JOIN ON
+                OR EXISTS -- adds blockers that are not also blockees
+                (SELECT * FROM blocked_pids bp2 WHERE psa.pid = ANY(bp2.blocked_by))
+              )
+          ),
+
+          sample_set_header as (
+            -- Details to record a sample set
+            -- even if there were no blockers
+            SELECT
+              current_database() sample_database,
+              NOW() sample_captured_at,
+              -- Include txid snapshot details so that txid epoch for backend_xid and backend_xmin
+              -- can be inferred; do not compare these directly to backend values without
+              -- accounting for epoch adjustment
+              txid_snapshot_xmin(txid_current_snapshot()) sample_txid_xmin,
+              txid_snapshot_xmax(txid_current_snapshot()) sample_txid_xmax,
+              ARRAY(SELECT txid_snapshot_xip(txid_current_snapshot())) sample_txid_xip
+          )
+
+          -- Sample set always return at least one row
+          -- including the timestamp and database
+          -- clients should check for the special case
+          -- of one row with a null pid meaning there were
+          -- no blockers or blockees in the sample set
+          SELECT
+            header.sample_database,
+            header.sample_captured_at,
+            header.sample_txid_xmin,
+            header.sample_txid_xmax,
+            header.sample_txid_xip,
+            bab.pid,
+            bab.usename::text "user",
+            bab.application_name source,
+            bab.client_addr,
+            bab.client_hostname,
+            bab.client_port,
+            bab.backend_start,
+            bab.xact_start,
+            bab.query_start,
+            bab.state_change,
+            bab.wait_event_type,
+            bab.wait_event,
+            bab.state,
+            bab.backend_xid::text::bigint, -- careful, wraps around, 32-bit unsigned value, no epoch
+            bab.backend_xmin::text::bigint, -- careful, wraps around, 32-bit unsigned value, no epoch
+            bab.query,
+            bab.backend_type,
+            bab.blocked_by
+          FROM
+            sample_set_header header
+          LEFT OUTER JOIN
+            blockers_and_blockees bab
+          ON TRUE
+          ORDER BY bab.pid
+        SQL
+
+        private_constant :BLOCKER_SAMPLE_SET_SQL
+      end
+
+      private
+
+      def supports_pg_blocking_pids?
+        # pg_blocking_pids introduced in Postgresql 9.6
+        # Release Note: https://www.postgresql.org/docs/9.6/release-9-6.html#AEN133618
+        # Current Doc:  https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE
+        #
+        # Previously complex queries on pg_locks were widely used but they are both convoluted and inferior so this
+        # feature is based only on pg_blocking_pids given that Postgres 9.6 has been available since Sept. 2016.
+        #
+        # Technical details on the improvements pg_blocking_pids introduced:
+        # https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=52f5d578d6c29bf254e93c69043b817d4047ca67
+        server_version_num >= PgConst::VERSION_9_6
+      end
+    end
+  end
+end

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -147,7 +147,7 @@ module PgHero
                 backend_xid,
                 backend_xmin,
                 query,
-                #{backed_type_col_available ? '' : 'null '}backend_type,
+                #{backed_type_col_available ? '' : 'null::text '}backend_type,
                 bp.blocked_by
               FROM
                 pg_stat_activity psa

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -14,12 +14,12 @@ module PgHero
         config['capture_query_blockers'] != false
       end
 
-      def capture_query_blockers(raise_errors: false, save_empty_samples: true)
+      def capture_query_blockers(save_empty_samples: true)
         return unless capture_query_blockers?
 
         sample_set = sample_query_blockers
         if !sample_set.sessions.empty? || save_empty_samples
-          repository.insert_query_blockers(sample_set, raise_errors: raise_errors)
+          repository.insert_query_blockers(sample_set)
         end
         sample_set
       end
@@ -74,6 +74,7 @@ module PgHero
         attr_accessor :id
 
         def initialize(database)
+          self.id = nil # No real id if not stored in the database
           records = database.select_all(SampleSet.blocker_sample_set_sql(database.server_version_num))
           first_record = records.first # Encodes whether the set has any real blockers
 

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -26,7 +26,7 @@ module PgHero
 
       def sample_query_blockers
         unless supports_pg_blocking_pids?
-          raise NotEnabled, 'Query blockers requires Postgres 9.6+ support for pg_blocking_pids. Actual version: #{server_version_num}'
+          raise NotEnabled, "Query blockers requires Postgres 9.6+ support for pg_blocking_pids. Actual version: #{server_version_num}"
         end
 
         SampleSet.new(self)

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -25,7 +25,9 @@ module PgHero
       end
 
       def sample_query_blockers
-        raise NotEnabled, 'Query blockers requires Postgres 9.6+ support for pg_blocking_pids' unless supports_pg_blocking_pids?
+        unless supports_pg_blocking_pids?
+          raise NotEnabled, 'Query blockers requires Postgres 9.6+ support for pg_blocking_pids. Actual version: #{server_version_num}'
+        end
 
         SampleSet.new(self)
       end
@@ -76,7 +78,7 @@ module PgHero
           first_record = records.first # Encodes whether the set has any real blockers
 
           @captured_at = first_record[:sample_captured_at]
-          @database = first_record[:sample_database]
+          @database = database.id  # TODO: decided whether or not to keep the native database string first_record[:sample_database]
           @txid_xmin = first_record[:sample_txid_xmin]
           @txid_xmax = first_record[:sample_txid_xmax]
           @txid_xip = first_record[:sample_txid_xip]

--- a/lib/pghero/methods/query_blockers.rb
+++ b/lib/pghero/methods/query_blockers.rb
@@ -111,7 +111,7 @@ module PgHero
           (blocker_session[:blocking] ||= []).push(blockee_pid)
         end
 
-        def self.build_blocker_sample_sql_const(backed_type_col_available)
+        def self.build_blocker_sample_sql_const(backend_type_col_available)
           # Include inline SQL comments to document nuances of the query
           # here (they execute fine); but they break internal quoting logic
           # (that removes newlines) so strip them out for runtime use
@@ -147,7 +147,7 @@ module PgHero
                 backend_xid,
                 backend_xmin,
                 query,
-                #{backed_type_col_available ? '' : 'null::text '}backend_type,
+                #{backend_type_col_available ? '' : 'null::text '}backend_type,
                 bp.blocked_by
               FROM
                 pg_stat_activity psa
@@ -219,7 +219,9 @@ module PgHero
 
         def self.blocker_sample_set_sql(pg_version)
           if (pg_version >= PgConst::VERSION_10)
-            @BLOCKER_SAMPLE_SET_SQL ||= build_blocker_sample_sql_const(true)
+            # TODO: Bug in pghero.pg_stat_activity view @ Instacart where backend_type column is missing
+            #@BLOCKER_SAMPLE_SET_SQL ||= build_blocker_sample_sql_const(true)
+            @BLOCKER_SAMPLE_SET_SQL ||= build_blocker_sample_sql_const(false)
           else
             @BLOCKER_SAMPLE_SET_SQL_PRE10 ||= build_blocker_sample_sql_const(false)
           end
@@ -242,4 +244,7 @@ module PgHero
       end
     end
   end
+  # wait_event_type
+  # wait_event
+
 end

--- a/lib/pghero/methods/query_blockers_history.rb
+++ b/lib/pghero/methods/query_blockers_history.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative 'type_const'
+
+module PgHero
+  module Methods
+    module QueryBlockersHistory
+
+      BLOCKER_SAMPLE_TABLE = 'pghero_blocker_samples'
+
+      BLOCKER_SAMPLE_SESSION_TABLE = 'pghero_blocker_sample_sessions'
+
+      ID_COL_LIST = TypeConst.const_column_list(id: TypeConst::BIGINT)
+
+      INSERT_BLOCKER_SAMPLE_COLS =
+        TypeConst.const_column_list(
+          database: TypeConst::TEXT,
+          captured_at: TypeConst::DATETIME,
+          txid_xmin: TypeConst::BIGINT,
+          txid_xmax: TypeConst::BIGINT,
+          txid_xip: TypeConst::BIGINT_ARRAY
+        )
+
+      INSERT_BLOCKER_SAMPLE_SESSION_COLS = (
+            TypeConst.const_column_list(blocker_sample_id: TypeConst::BIGINT) +
+            QueryBlockers::SampleSet::BLOCKER_ATTRIBUTE_COLUMNS
+          ).freeze
+
+      private_constant :BLOCKER_SAMPLE_TABLE,
+                       :BLOCKER_SAMPLE_SESSION_TABLE,
+                       :ID_COL_LIST,
+                       :INSERT_BLOCKER_SAMPLE_COLS,
+                       :INSERT_BLOCKER_SAMPLE_SESSION_COLS
+
+      def supports_query_blocker_history?(raise_on_unsupported: false)
+        return @blockers_tables_usable if @blockers_tables_usable
+
+        missing_tables = self.missing_tables(BLOCKER_SAMPLE_TABLE, BLOCKER_SAMPLE_SESSION_TABLE)
+        @blocker_tables_usable = missing_tables.empty?
+
+        if !@blocker_tables_usable && raise_on_unsupported
+          raise NotEnabled, "Missing table(s): #{missing_tables.join(', ')} are required to track blocker history"
+        end
+
+        @blocker_tables_usable
+      end
+
+      def insert_query_blockers(sample_set, raise_errors: false)
+        return unless supports_query_blocker_history?(raise_on_unsupported: raise_errors)
+
+        with_transaction do # Might already be in a transaction; that's fine
+          sample_set.id = insert_query_blocker_sample(sample_set)
+          unless sample_set.sessions.empty?
+            # Maximum 1K records at a time to keep the SQL INSERT string "reasonable"
+            sample_set.sessions.each_slice(1000) do |session_batch|
+              insert_session_batch(sample_set.id, session_batch)
+            end
+          end
+        end
+        sample_set.id
+      end
+
+      # TODO: add support for querying historical data
+
+      private
+
+      def insert_query_blocker_sample(sample_set)
+        result = insert_typed(BLOCKER_SAMPLE_TABLE,
+                        INSERT_BLOCKER_SAMPLE_COLS,
+                        [sample_values(sample_set)],
+                        typed_return_cols: ID_COL_LIST)
+        result.first[:id.to_s]
+      end
+
+      def insert_session_batch(sample_id, session_batch)
+        result = insert_typed(BLOCKER_SAMPLE_SESSION_TABLE,
+                        INSERT_BLOCKER_SAMPLE_SESSION_COLS,
+                        session_values(sample_id, session_batch),
+                        typed_return_cols: ID_COL_LIST)
+        session_batch.each.with_index do |session, idx|
+          session[:id] = result[idx][:id.to_s]
+        end
+      end
+
+      def sample_values(sample_set)
+        INSERT_BLOCKER_SAMPLE_COLS.map { |col| sample_set.send(col.name) }
+      end
+
+      def session_values(sample_id, session_batch)
+        session_batch.map do |session|
+          INSERT_BLOCKER_SAMPLE_SESSION_COLS.map.with_index do |col, idx|
+            col.name == :blocker_sample_id ? sample_id : session[col.name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pghero/methods/query_blockers_history.rb
+++ b/lib/pghero/methods/query_blockers_history.rb
@@ -45,8 +45,8 @@ module PgHero
         @blocker_tables_usable
       end
 
-      def insert_query_blockers(sample_set, raise_errors: false)
-        return unless supports_query_blocker_history?(raise_on_unsupported: raise_errors)
+      def insert_query_blockers(sample_set)
+        return unless supports_query_blocker_history?(raise_on_unsupported: true)
 
         with_transaction do # Might already be in a transaction; that's fine
           sample_set.id = insert_query_blocker_sample(sample_set)

--- a/lib/pghero/methods/replication.rb
+++ b/lib/pghero/methods/replication.rb
@@ -12,7 +12,7 @@ module PgHero
       def replication_lag
         with_feature_support(:replication_lag) do
           lag_condition =
-            if server_version_num >= 100000
+            if server_version_num >= PgConst::VERSION_10
               "pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()"
             else
               "pg_last_xlog_receive_location() = pg_last_xlog_replay_location()"
@@ -30,7 +30,7 @@ module PgHero
       end
 
       def replication_slots
-        if server_version_num >= 90400
+        if server_version_num >= PgConst::VERSION_9_4
           with_feature_support(:replication_slots, []) do
             select_all <<-SQL
               SELECT

--- a/lib/pghero/methods/repository.rb
+++ b/lib/pghero/methods/repository.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'active_record'
+
+module PgHero
+  module Methods
+    module Repository
+
+      def insert(table, column_names, values_table, return_cols: nil)
+        quoted_column_list = quote_column_names(column_names)
+
+        row_sql_list = values_table.map do |row_values|
+          "(#{quote_row_values(row_values).join(',')})"
+        end
+
+        quoted_return_list = return_cols ? quote_column_names(return_cols) : nil
+        _insert(table, quoted_column_list, row_sql_list, quoted_return_list)
+      end
+
+      def insert_typed(table, typed_columns, values_table, typed_return_cols: nil)
+        quoted_column_list = quote_typed_column_names(typed_columns)
+
+        row_sql_list = values_table.map do |row_values|
+          "(#{quote_typed_row_values(typed_columns, row_values).join(',')})"
+        end
+
+        quoted_return_list = typed_return_cols ? quote_typed_column_names(typed_return_cols) : nil
+        _insert(table, quoted_column_list, row_sql_list, quoted_return_list)
+      end
+
+      private
+
+      def _insert(table, quoted_column_list, rows_sql_list, quoted_return_list)
+        column_sql = quoted_column_list.join(',')
+        values_sql = rows_sql_list.join(',')
+
+        insert_sql = <<-SQL
+          INSERT INTO #{quote_table_name(table)}
+            (#{column_sql})
+          VALUES
+            #{values_sql}
+        SQL
+
+        if quoted_return_list
+          insert_sql += <<-SQL if quoted_return_list
+          RETURNING
+            #{quoted_return_list.join(',')}
+          SQL
+        end
+        connection.execute(insert_sql)
+      end
+
+      def quote_column_names(col_names)
+        connection = self.connection
+        col_names.map do |col_name|
+          connection.quote_table_name(col_name)
+        end
+      end
+
+      def quote_row_values(row_values)
+        row_values.map do |value|
+          connection.quote(value)
+        end
+      end
+
+      def quote_typed_column_names(typed_columns)
+        connection = self.connection
+        typed_columns.map { |col| col.quote_name(connection) }
+      end
+
+      def quote_typed_row_values(typed_columns, row_values)
+        connection = self.connection
+        typed_columns.map.with_index do |typed_col, idx|
+          typed_col.quote_value(connection, row_values[idx])
+        end
+      end
+    end
+  end
+end

--- a/lib/pghero/methods/settings.rb
+++ b/lib/pghero/methods/settings.rb
@@ -3,7 +3,7 @@ module PgHero
     module Settings
       def settings
         names =
-          if server_version_num >= 90500
+          if server_version_num >= PgConst::VERSION_9_5
             %i(
               max_connections shared_buffers effective_cache_size work_mem
               maintenance_work_mem min_wal_size max_wal_size checkpoint_completion_target

--- a/lib/pghero/methods/space.rb
+++ b/lib/pghero/methods/space.rb
@@ -52,7 +52,7 @@ module PgHero
           sizes = Hash[ relation_sizes.map { |r| [[r[:schema], r[:relation]], r[:size_bytes]] } ]
           start_at = days.days.ago
 
-          stats = select_all_stats <<-SQL
+          stats = repository.select_all <<-SQL
             WITH t AS (
               SELECT
                 schema,
@@ -95,7 +95,7 @@ module PgHero
           sizes = Hash[ relation_sizes.map { |r| [[r[:schema], r[:relation]], r[:size_bytes]] } ]
           start_at = 30.days.ago
 
-          stats = select_all_stats <<-SQL
+          stats = repository.select_all <<-SQL
             SELECT
               captured_at,
               size AS size_bytes
@@ -126,11 +126,11 @@ module PgHero
         relation_sizes.each do |rs|
           values << [id, rs[:schema], rs[:relation], rs[:size_bytes].to_i, now]
         end
-        insert_stats("pghero_space_stats", columns, values) if values.any?
+        repository.insert("pghero_space_stats", columns, values) if values.any?
       end
 
       def space_stats_enabled?
-        table_exists?("pghero_space_stats")
+        repository.table_exists?("pghero_space_stats")
       end
     end
   end

--- a/lib/pghero/methods/type_const.rb
+++ b/lib/pghero/methods/type_const.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module PgHero
+  module Methods
+    module TypeConst
+
+      def self.lookup_type(*args, **kwargs)
+        ActiveRecord::Type.lookup(*args, adapter: :postgresql, **kwargs)
+      end
+
+      BIGINT = lookup_type(:integer, limit: 8)
+      BIGINT_ARRAY = lookup_type(:integer, limit: 8, array: true) # PG specific
+      BOOLEAN = lookup_type(:boolean)
+      DATE = lookup_type(:date)
+      DATETIME = lookup_type(:datetime)
+      DECIMAL = lookup_type(:decimal)
+      FLOAT = lookup_type(:float)
+      INET = lookup_type(:inet) # PG specific
+      INTEGER = lookup_type(:integer)
+      INTEGER_ARRAY = lookup_type(:integer, array: true) # PG specific
+      STRING = lookup_type(:string)
+      TEXT = lookup_type(:text)
+      TIME = lookup_type(:time)
+
+      # XID is a 32-bit unsigned value that eventually wraps;
+      # store in BIGINT to avoid negatives. Not the same as a
+      # BIGINT txid value that is actually 64-bits with an
+      # epoch to avoid wraparound
+      XID = BIGINT
+
+      def self.define_column(name, type)
+        TypedColumn.new(name, type)
+      end
+
+      def self.const_column_list(**kwargs)
+        kwargs.each_pair.map do |col_name, col_type|
+          define_column(col_name, col_type)
+        end.freeze
+      end
+
+      class TypedColumn
+        attr_reader :name
+
+        def initialize(name, type)
+          @name = name.to_sym
+          @type = type
+          freeze
+        end
+
+        def quote_name(connection)
+          connection.quote_table_name(@name)
+        end
+
+        def quote_value(connection, value)
+          connection.quote(@type.serialize(value))
+        end
+      end
+
+      private_class_method :lookup_type
+    end
+  end
+end
+

--- a/lib/pghero/pg_const.rb
+++ b/lib/pghero/pg_const.rb
@@ -1,0 +1,8 @@
+module PgHero
+  module PgConst
+    VERSION_9_4 =  9_04_00
+    VERSION_9_5 =  9_05_00
+    VERSION_9_6 =  9_06_00
+    VERSION_10  = 10_00_00
+  end
+end

--- a/lib/pghero/query_stats.rb
+++ b/lib/pghero/query_stats.rb
@@ -1,7 +1,0 @@
-module PgHero
-  class QueryStats < ActiveRecord::Base
-    self.abstract_class = true
-    self.table_name = "pghero_query_stats"
-    establish_connection ENV["PGHERO_STATS_DATABASE_URL"] if ENV["PGHERO_STATS_DATABASE_URL"]
-  end
-end

--- a/lib/pghero/repository.rb
+++ b/lib/pghero/repository.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'active_record'
+
+module PgHero
+  class Repository < BaseDatabase
+    # Repository extends BaseDatabase and not Database (aka MonitoredDatabase)
+    # because we keep separate connections for monitoring vs repository access
+    # even when monitoring the repository itself. This keeps the logic,
+    # transaction isolation, etc completely segregated.
+
+    include Methods::Repository
+    include Methods::QueryBlockersHistory
+
+    private
+
+    def connection_model
+      QueryStats
+    end
+
+    class QueryStats < ActiveRecord::Base
+      self.abstract_class = true
+      self.table_name = 'pghero_query_stats'
+      establish_connection ENV['PGHERO_STATS_DATABASE_URL'] if ENV['PGHERO_STATS_DATABASE_URL']
+    end
+  end
+end

--- a/lib/pghero/version.rb
+++ b/lib/pghero/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PgHero
   VERSION = "2.3.0"
 end

--- a/lib/tasks/pghero.rake
+++ b/lib/tasks/pghero.rake
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 namespace :pghero do
-  desc "capture query stats"
+  desc 'capture query stats'
   task capture_query_stats: :environment do
     PgHero.capture_query_stats(verbose: true)
   end
 
-  desc "capture space stats"
+  desc 'capture space stats'
   task capture_space_stats: :environment do
     PgHero.capture_space_stats(verbose: true)
   end
 
-  desc "capture connection stats"
+  desc 'capture connection stats'
   task capture_connection_stats: :environment do
     PgHero.capture_connection_stats(verbose: true)
   end
@@ -21,10 +23,10 @@ namespace :pghero do
 
   desc "analyze tables"
   task analyze: :environment do
-    PgHero.analyze_all(verbose: true, min_size: ENV["MIN_SIZE_GB"].to_f.gigabytes)
+    PgHero.analyze_all(verbose: true, min_size: ENV['MIN_SIZE_GB'].to_f.gigabytes)
   end
 
-  desc "autoindex"
+  desc 'autoindex'
   task autoindex: :environment do
     PgHero.autoindex_all(verbose: true, create: true)
   end

--- a/lib/tasks/pghero.rake
+++ b/lib/tasks/pghero.rake
@@ -17,8 +17,11 @@ namespace :pghero do
   end
 
   desc 'capture_query_blockers'
-  task capture_query_blockers: :environment do
-    PgHero.capture_query_blockers(verbose: true)
+  task :capture_query_blockers, [:dbid_filters] => :environment do |t, task_args|
+    args = task_args.to_a
+    filters = args.empty? ? nil : args.map { |s| Regexp.new(s) }
+
+    PgHero.capture_query_blockers(verbose: true, filters: filters)
   end
 
   desc "analyze tables"

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
 class BasicTest < Minitest::Test
   def setup

--- a/test/capture_test.rb
+++ b/test/capture_test.rb
@@ -3,11 +3,33 @@
 require_relative 'test_helper'
 
 class CaptureTest < Minitest::Test
-
-  def test_capture_query_blockers
-    # TODO: test needs to be in a transaction rollback as soon
-    # as capture_query_blockers implements real inserts
-    assert PgHero.capture_query_blockers(verbose: true)
+  def test_primary_database_capture_query_stats
+    stats_repository.with_transaction(rollback: rollback_enabled?) do
+      assert primary_database.capture_query_stats(raise_errors: true)
+    end
   end
 
+  def test_capture_query_stats
+    stats_repository.with_transaction(rollback: rollback_enabled?) do
+      assert PgHero.capture_query_stats(verbose: true)
+    end
+  end
+
+  def test_capture_space_stats
+    stats_repository.with_transaction(rollback: rollback_enabled?) do
+      assert PgHero.capture_space_stats(verbose: true)
+    end
+  end
+
+  def test_capture_query_stats
+    stats_repository.with_transaction(rollback: rollback_enabled?) do
+      assert PgHero.capture_query_stats(verbose: true)
+    end
+  end
+
+  def test_capture_connection_stats
+    stats_repository.with_transaction(rollback: rollback_enabled?) do
+      assert PgHero.capture_connection_stats(verbose: true)
+    end
+  end
 end

--- a/test/query_blockers_test.rb
+++ b/test/query_blockers_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class QueryBlockersTest < Minitest::Test
+
+  def test_primary_database_current_blockers
+    assert primary_database.sample_query_blockers
+  end
+
+  def test_primary_database_capture_blockers_return
+    run_with_blockers(rollback: rollback_enabled?) do
+      blocker_sample = primary_database.capture_query_blockers(raise_errors: true)
+      assert blocker_sample.sessions.size == 2
+    end
+  end
+
+  def test_capture_blockers
+    run_with_blockers(rollback: rollback_enabled?) do
+      assert PgHero.capture_query_blockers(verbose: true)
+    end
+  end
+
+  private
+
+  def run_with_blockers(rollback: true)
+    # TODO: ideally we would use a third thread to separate the
+    # transaction/connection used for storing historical stat
+    User.transaction do
+      locked_user = User.all.first
+      locked_user.active = !locked_user.active
+      locked_user.save
+
+      t = lock_user_in_separate_thread(locked_user.id)
+      # Give thread one second to block on the DB lock;
+      # test could fail if DB is too slow - increase block time if needed
+      t.join(1)
+      yield
+      raise ActiveRecord::Rollback, 'Test - do not save anything' if rollback
+    end
+  end
+
+  def lock_user_in_separate_thread(user_id)
+    Thread.new do
+      # No full Rails dependency so can't use Rails.application.executor.wrap; use older with_connection mechanism
+      ActiveRecord::Base.connection_pool.with_connection do
+        # Will block on the main thread holding the row lock until the main transaction completes
+        User.transaction do
+          User.find(user_id).lock!
+        end
+      end
+    end
+  end
+end

--- a/test/query_blockers_test.rb
+++ b/test/query_blockers_test.rb
@@ -10,7 +10,7 @@ class QueryBlockersTest < Minitest::Test
 
   def test_primary_database_capture_blockers_return
     run_with_blockers(rollback: rollback_enabled?) do
-      blocker_sample = primary_database.capture_query_blockers(raise_errors: true)
+      blocker_sample = primary_database.capture_query_blockers
       assert blocker_sample.sessions.size == 2
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,3 +66,16 @@ users =
   end
 User.import users, validate: false
 ActiveRecord::Base.connection.execute("ANALYZE users")
+
+def primary_database
+  PgHero.databases[:primary]
+end
+
+def stats_repository
+  primary_database.send :repository
+end
+
+def rollback_enabled?
+  false # TODO: JRD - turn this back off
+end
+


### PR DESCRIPTION
The feature is modeled after other historical data tracking in PgHero (e.g. query stats). The tracked stats are not shown in PgHero UI yet (it still shows the older live blockers information with no history) but will be visible via direct table queries. Separate PR will enable rendering of query blockers.

Each sample creates a row in pghero_blocker_samples even if there are no blockers; this is to ensure that historical data can be accurately distinguished from missing data. Actual blockers and blockees are stored in pghero_blocker_sample_sessions.

The PR also restructures the base methods and objects to cleanly separate the monitored DB from the respository used to store historical data and allow reuse of methods for both cases. It also includes minor cosmetic changes to files that were touched to accomplish the restructuring (e.g. RuboCop suggestions on strings, etc).